### PR TITLE
[PR] 동아리 관리 기능 구현

### DIFF
--- a/src/main/java/com/ac/su/clubmember/ClubMemberRepository.java
+++ b/src/main/java/com/ac/su/clubmember/ClubMemberRepository.java
@@ -13,4 +13,7 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, ClubMemb
     //     findByMember(Long memberId);
     List<ClubMember> findByClubId(Long clubId);
     boolean existsById(ClubMemberId clubMemberId);
+
+    // 특정 등급의 동아리 회원을 검색하는 메소드
+    ClubMember findByClubIdAndStatus(Long clubId, MemberStatus status);
 }

--- a/src/main/java/com/ac/su/clubmember/ClubMemberRestController.java
+++ b/src/main/java/com/ac/su/clubmember/ClubMemberRestController.java
@@ -39,19 +39,15 @@ public class ClubMemberRestController {
     @PostMapping("/{clubId}/clubMember/{memberId}/changeStatus")
     public ResponseEntity<?> changeStatus(@PathVariable("memberId") Long memberId,
                                           @PathVariable("clubId") Long clubId,
-                                          @RequestParam("status") MemberStatus status,
                                           @RequestParam("changeStatus") MemberStatus changeStatus,
                                           Authentication auth) {
+        // 회원 상태 가져오기
         CustonUser user = (CustonUser) auth.getPrincipal();
-        // 동아리 회장이 아닐 때
+        MemberStatus status = clubMemberService.getMemberStatus(new ClubMemberId(user.getId(), clubId));
+
+        // 동아리 회장이 아닌 경우 접근 금지
         if (status != MemberStatus.CLUB_PRESIDENT) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
-        }
-        // 동아리 회장일 때
-        // PathVariable로 받은 동아리의 회장인지 검사
-        else {
-            if (!clubMemberService.existsById(user.getId(), clubId))
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 
         // 회원 상태 수정
@@ -64,18 +60,14 @@ public class ClubMemberRestController {
     @PostMapping("/{clubId}/clubMember/{memberId}/deleteMember")
     public ResponseEntity<?> deleteMember(@PathVariable("memberId") Long memberId,
                                           @PathVariable("clubId") Long clubId,
-                                          @RequestParam("status") MemberStatus status,
                                           Authentication auth) {
+        // 회원 상태 가져오기
         CustonUser user = (CustonUser) auth.getPrincipal();
-        // 동아리 회장이 아닐 때
+        MemberStatus status = clubMemberService.getMemberStatus(new ClubMemberId(user.getId(), clubId));
+
+        // 동아리 회장이 아닌 경우 접근 금지
         if (status != MemberStatus.CLUB_PRESIDENT) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
-        }
-        // 동아리 회장일 때
-        // PathVariable로 받은 동아리의 회장인지 검사
-        else {
-            if (!clubMemberService.existsById(user.getId(), clubId))
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 
         // 회원 삭제

--- a/src/main/java/com/ac/su/clubmember/ClubMemberRestController.java
+++ b/src/main/java/com/ac/su/clubmember/ClubMemberRestController.java
@@ -1,6 +1,7 @@
 package com.ac.su.clubmember;
 
 import com.ac.su.ResponseMessage;
+import com.ac.su.member.CustonUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +14,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/clubs")
+@RequestMapping("/clubs")
 public class ClubMemberRestController {
     private final ClubMemberService clubMemberService;
     private final ClubMemberRepository clubMemberRepository;
@@ -41,6 +42,7 @@ public class ClubMemberRestController {
                                           @RequestParam("status") MemberStatus status,
                                           @RequestParam("changeStatus") MemberStatus changeStatus,
                                           Authentication auth) {
+        CustonUser user = (CustonUser) auth.getPrincipal();
         // 동아리 회장이 아닐 때
         if (status != MemberStatus.CLUB_PRESIDENT) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
@@ -48,7 +50,7 @@ public class ClubMemberRestController {
         // 동아리 회장일 때
         // PathVariable로 받은 동아리의 회장인지 검사
         else {
-            if (!clubMemberService.existsById(Long.valueOf(auth.getName()), clubId))
+            if (!clubMemberService.existsById(user.getId(), clubId))
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 
@@ -64,6 +66,7 @@ public class ClubMemberRestController {
                                           @PathVariable("clubId") Long clubId,
                                           @RequestParam("status") MemberStatus status,
                                           Authentication auth) {
+        CustonUser user = (CustonUser) auth.getPrincipal();
         // 동아리 회장이 아닐 때
         if (status != MemberStatus.CLUB_PRESIDENT) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
@@ -71,7 +74,7 @@ public class ClubMemberRestController {
         // 동아리 회장일 때
         // PathVariable로 받은 동아리의 회장인지 검사
         else {
-            if (!clubMemberService.existsById(Long.valueOf(auth.getName()), clubId))
+            if (!clubMemberService.existsById(user.getId(), clubId))
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 

--- a/src/main/java/com/ac/su/clubmember/ClubMemberService.java
+++ b/src/main/java/com/ac/su/clubmember/ClubMemberService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -48,5 +49,18 @@ public class ClubMemberService {
     public boolean existsById(Long memberId, Long clubId) {
         ClubMemberId clubMemberId = new ClubMemberId(memberId, clubId);
         return clubMemberRepository.existsById(clubMemberId);
+    }
+
+    // 동아리 회원의 등급 확인
+    public MemberStatus getMemberStatus(ClubMemberId clubMemberId) {
+        Optional<ClubMember> clubMember = clubMemberRepository.findById(clubMemberId);
+
+        // 회원이 특정 동아리에 속해 있는지 확인하고 상태를 반환
+        if (clubMember.isPresent()) {
+            return clubMember.get().getStatus();
+        } else {
+            // 동아리에 속해 있지 않으면 예외 발생
+            throw new IllegalArgumentException("회원이 동아리에 가입되지 않았습니다.");
+        }
     }
 }

--- a/src/main/java/com/ac/su/clubmember/ClubMemberService.java
+++ b/src/main/java/com/ac/su/clubmember/ClubMemberService.java
@@ -1,7 +1,9 @@
 package com.ac.su.clubmember;
 
+import com.ac.su.community.club.Club;
 import com.ac.su.community.club.ClubRepository;
 import com.ac.su.member.MemberRepository;
+import com.ac.su.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -62,5 +64,14 @@ public class ClubMemberService {
             // 동아리에 속해 있지 않으면 예외 발생
             throw new IllegalArgumentException("회원이 동아리에 가입되지 않았습니다.");
         }
+    }
+
+    // 동아리 회장 위임
+    public void delegatePresident(Long clubId) {
+        // 동아리 회장 검색
+        ClubMember clubPresident = clubMemberRepository.findByClubIdAndStatus(clubId, MemberStatus.CLUB_PRESIDENT);
+        // 회장 -> 일반 회원
+        clubPresident.setStatus(MemberStatus.CLUB_MEMBER);
+        clubMemberRepository.save(clubPresident);
     }
 }

--- a/src/main/java/com/ac/su/clubmember/ClubMemberViewController.java
+++ b/src/main/java/com/ac/su/clubmember/ClubMemberViewController.java
@@ -1,53 +1,53 @@
-package com.ac.su.clubmember;
-
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-
-@Controller
-@RequiredArgsConstructor
-@RequestMapping("/clubs")
-public class ClubMemberViewController {
-    private final ClubMemberService clubMemberService;
-
-    // 동아리 id에 따른 동아리 회원 리스트 출력
-    @GetMapping("/{clubId}/clubMember")
-    public String clubMemberList(@PathVariable("clubId") Long clubId,
-                                 Model model) {
-        List<ClubMemberDTO> clubMemberDTOList = clubMemberService.findAllByClubId(clubId);
-        model.addAttribute("clubMemberList", clubMemberDTOList);
-        return "club_member_list";
-    }
-
-    // 회원 상세 정보
-    @GetMapping("/{clubId}/clubMember/{memberId}")
-    public String memberDetail(@PathVariable("memberId") Long memberId,
-                               @PathVariable("clubId") Long clubId,
-                               Model model) {
-        ClubMemberDTO clubMemberDTO = clubMemberService.findByMemberId(memberId, clubId);
-        model.addAttribute("clubMember", clubMemberDTO);
-        return "club_member_detail";
-    }
-
-    // 회원 상태 수정
-    @PostMapping("/{clubId}/clubMember/{memberId}/changeStatus")
-    public String changeStatus(@PathVariable("memberId") Long memberId,
-                               @PathVariable("clubId") Long clubId,
-                               @RequestParam("status") MemberStatus status) {
-        clubMemberService.changeStatus(memberId, clubId, status);
-        // 회원 상태 수정 후 회원 리스트로 리다이렉트
-        return "redirect:/clubs/" + clubId + "/clubMember";
-    }
-
-    // 회원 삭제
-    @PostMapping("/{clubId}/clubMember/{memberId}/deleteMember")
-    public String deleteMember(@PathVariable("memberId") Long memberId,
-                               @PathVariable("clubId") Long clubId) {
-        clubMemberService.deleteMember(memberId, clubId);
-        // 회원 삭제 후 회원 리스트로 리다이렉트
-        return "redirect:/clubs/" + clubId + "/clubMember";
-    }
-}
+//package com.ac.su.clubmember;
+//
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.stereotype.Controller;
+//import org.springframework.ui.Model;
+//import org.springframework.web.bind.annotation.*;
+//
+//import java.util.List;
+//
+//@Controller
+//@RequiredArgsConstructor
+//@RequestMapping("/clubs")
+//public class ClubMemberViewController {
+//    private final ClubMemberService clubMemberService;
+//
+//    // 동아리 id에 따른 동아리 회원 리스트 출력
+//    @GetMapping("/{clubId}/clubMember")
+//    public String clubMemberList(@PathVariable("clubId") Long clubId,
+//                                 Model model) {
+//        List<ClubMemberDTO> clubMemberDTOList = clubMemberService.findAllByClubId(clubId);
+//        model.addAttribute("clubMemberList", clubMemberDTOList);
+//        return "club_member_list";
+//    }
+//
+//    // 회원 상세 정보
+//    @GetMapping("/{clubId}/clubMember/{memberId}")
+//    public String memberDetail(@PathVariable("memberId") Long memberId,
+//                               @PathVariable("clubId") Long clubId,
+//                               Model model) {
+//        ClubMemberDTO clubMemberDTO = clubMemberService.findByMemberId(memberId, clubId);
+//        model.addAttribute("clubMember", clubMemberDTO);
+//        return "club_member_detail";
+//    }
+//
+//    // 회원 상태 수정
+//    @PostMapping("/{clubId}/clubMember/{memberId}/changeStatus")
+//    public String changeStatus(@PathVariable("memberId") Long memberId,
+//                               @PathVariable("clubId") Long clubId,
+//                               @RequestParam("status") MemberStatus status) {
+//        clubMemberService.changeStatus(memberId, clubId, status);
+//        // 회원 상태 수정 후 회원 리스트로 리다이렉트
+//        return "redirect:/clubs/" + clubId + "/clubMember";
+//    }
+//
+//    // 회원 삭제
+//    @PostMapping("/{clubId}/clubMember/{memberId}/deleteMember")
+//    public String deleteMember(@PathVariable("memberId") Long memberId,
+//                               @PathVariable("clubId") Long clubId) {
+//        clubMemberService.deleteMember(memberId, clubId);
+//        // 회원 삭제 후 회원 리스트로 리다이렉트
+//        return "redirect:/clubs/" + clubId + "/clubMember";
+//    }
+//}

--- a/src/main/java/com/ac/su/community/club/ClubController.java
+++ b/src/main/java/com/ac/su/community/club/ClubController.java
@@ -2,10 +2,7 @@ package com.ac.su.community.club;
 
 
 import com.ac.su.ResponseMessage;
-import com.ac.su.clubmember.ClubMember;
-import com.ac.su.clubmember.ClubMemberRepository;
-import com.ac.su.clubmember.ClubMemberService;
-import com.ac.su.clubmember.MemberStatus;
+import com.ac.su.clubmember.*;
 import com.ac.su.member.CustonUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -85,18 +82,14 @@ public class ClubController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/clubs/{clubId}/changeClubInfo")
     public ResponseEntity<?> getClubInfo(@PathVariable("clubId") Long clubId,
-                                         @RequestParam("status") MemberStatus status,
                                          Authentication auth) {
+        // 회원 상태 가져오기
         CustonUser user = (CustonUser) auth.getPrincipal();
-        // 동아리 회장이 아닐 때
+        MemberStatus status = clubMemberService.getMemberStatus(new ClubMemberId(user.getId(), clubId));
+
+        // 동아리 회장이 아닌 경우 접근 금지
         if (status != MemberStatus.CLUB_PRESIDENT) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
-        }
-        // 동아리 회장일 때
-        // PathVariable로 받은 동아리의 회장인지 검사
-        else {
-            if (!clubMemberService.existsById(user.getId(), clubId))
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 
         // 동아리 정보 불러옴

--- a/src/main/java/com/ac/su/community/club/ClubDTO.java
+++ b/src/main/java/com/ac/su/community/club/ClubDTO.java
@@ -1,21 +1,38 @@
 package com.ac.su.community.club;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import com.ac.su.clubmember.ClubMember;
+import com.ac.su.clubmember.ClubMemberDTO;
+import com.ac.su.member.Member;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
 public class ClubDTO {
     private Long clubId;
     private String clubName;
     private String description;
     private String category;
-    private Long memberId;
+    private Long member;
     @CreationTimestamp
     private LocalDateTime createdAt;
     private String clubImgUrl;
+    private String clubSlogan;
 
+    // 동아리 수정 기능에서 표시될 내용입니다
+    // (일부러 동아리 이름, 동아리 슬로건, 동아리 설명만 표시되게 만들었어요!!)
+    public static ClubDTO toClubDTO(Club club){
+        ClubDTO clubDTO = new ClubDTO();
+        clubDTO.setClubName(club.getName());
+        clubDTO.setClubSlogan(club.getClubSlogan());
+        clubDTO.setDescription(club.getDescription());
+
+        return clubDTO;
+    }
 }

--- a/src/main/java/com/ac/su/community/club/ClubDTO.java
+++ b/src/main/java/com/ac/su/community/club/ClubDTO.java
@@ -25,12 +25,13 @@ public class ClubDTO {
     private String clubSlogan;
 
     // 동아리 수정 기능에서 표시될 내용입니다
-    // (일부러 동아리 이름, 동아리 슬로건, 동아리 설명만 표시되게 만들었어요!!)
+    // (일부러 동아리 이름, 동아리 슬로건, 동아리 설명, 동아리 이미지만 표시되게 만들었어요!!)
     public static ClubDTO toClubDTO(Club club){
         ClubDTO clubDTO = new ClubDTO();
         clubDTO.setClubName(club.getName());
         clubDTO.setClubSlogan(club.getClubSlogan());
         clubDTO.setDescription(club.getDescription());
+        clubDTO.setClubImgUrl(club.getClubImgUrl());
 
         return clubDTO;
     }

--- a/src/main/java/com/ac/su/community/club/ClubService.java
+++ b/src/main/java/com/ac/su/community/club/ClubService.java
@@ -126,13 +126,19 @@ public class ClubService {
     }
 
     // 동아리 정보 수정
-    public void changeClubInfo(Long clubId, String clubName, String clubSlogan, String description) {
+    public void changeClubInfo(Long clubId, String clubName, String clubSlogan, String description, String clubImgUrl) {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new IllegalArgumentException("동아리에 가입되지 않은 회원입니다."));
         club.setName(clubName);
         club.setClubSlogan(clubSlogan);
         club.setDescription(description);
+        club.setClubImgUrl(clubImgUrl);
 
         clubRepository.save(club);
+    }
+
+    // 동아리 삭제
+    public void deleteClub(Long clubId) {
+        clubRepository.deleteById(clubId);
     }
 }
 

--- a/src/main/java/com/ac/su/joinrequest/JoinRequestController.java
+++ b/src/main/java/com/ac/su/joinrequest/JoinRequestController.java
@@ -29,42 +29,43 @@ public class JoinRequestController {
         return message;
     }
 
-    // 동아리 id에 따른 동아리 지원서 리스트 출력
-    @GetMapping("/{clubId}/joinRequest")
-    public String joinRequestList(@PathVariable("clubId") Long requestId,
-                                 Model model) {
-        List<JoinRequestDTO> joinRequestDTOList = joinRequestService.findRequestByClubId(requestId);
-        model.addAttribute("joinRequestList", joinRequestDTOList);
-        return "join_request_list";
-    }
-
-    // 동아리 지원서 상세 정보
-    @GetMapping("/{clubId}/joinRequest/{requestId}")
-    public String requestDetail(@PathVariable("requestId") Long requestId,
-                               Model model) {
-        JoinRequestDTO joinRequestDTO = joinRequestService.findByRequestId(requestId);
-        model.addAttribute("joinRequest", joinRequestDTO);
-        return "join_request_detail";
-    }
-
-    // 가입 승인
-    @PostMapping("/{clubId}/joinRequest/{requestId}/approveRequest")
-    public String approveRequest(@PathVariable("requestId") Long requestId,
-                                 @PathVariable("clubId") Long clubId,
-                                 @RequestParam("memberId") Long memberId) {
-        joinRequestService.approveRequest(requestId, clubId, memberId);
-        // 가입 승인 후 동아리 지원서 리스트로 리다이렉트
-        return "redirect:/clubs/" + clubId + "/joinRequest";
-    }
-
-    // 가입 거절
-    @PostMapping("/{clubId}/joinRequest/{requestId}/denyRequest")
-    public String denyRequest(@PathVariable("requestId") Long requestId,
-                              @PathVariable("clubId") Long clubId) {
-        joinRequestService.denyRequest(requestId);
-        // 가입 거절 후 회원 리스트로 리다이렉트
-        return "redirect:/clubs/" + clubId + "/joinRequest";
-    }
+    // 이 밑부터는 JoinRequestRestController 코드로 이동했습니다
+//    // 동아리 id에 따른 동아리 지원서 리스트 출력
+//    @GetMapping("/{clubId}/joinRequest")
+//    public String joinRequestList(@PathVariable("clubId") Long requestId,
+//                                 Model model) {
+//        List<JoinRequestDTO> joinRequestDTOList = joinRequestService.findRequestByClubId(requestId);
+//        model.addAttribute("joinRequestList", joinRequestDTOList);
+//        return "join_request_list";
+//    }
+//
+//    // 동아리 지원서 상세 정보
+//    @GetMapping("/{clubId}/joinRequest/{requestId}")
+//    public String requestDetail(@PathVariable("requestId") Long requestId,
+//                               Model model) {
+//        JoinRequestDTO joinRequestDTO = joinRequestService.findByRequestId(requestId);
+//        model.addAttribute("joinRequest", joinRequestDTO);
+//        return "join_request_detail";
+//    }
+//
+//    // 가입 승인
+//    @PostMapping("/{clubId}/joinRequest/{requestId}/approveRequest")
+//    public String approveRequest(@PathVariable("requestId") Long requestId,
+//                                 @PathVariable("clubId") Long clubId,
+//                                 @RequestParam("memberId") Long memberId) {
+//        joinRequestService.approveRequest(requestId, clubId, memberId);
+//        // 가입 승인 후 동아리 지원서 리스트로 리다이렉트
+//        return "redirect:/clubs/" + clubId + "/joinRequest";
+//    }
+//
+//    // 가입 거절
+//    @PostMapping("/{clubId}/joinRequest/{requestId}/denyRequest")
+//    public String denyRequest(@PathVariable("requestId") Long requestId,
+//                              @PathVariable("clubId") Long clubId) {
+//        joinRequestService.denyRequest(requestId);
+//        // 가입 거절 후 회원 리스트로 리다이렉트
+//        return "redirect:/clubs/" + clubId + "/joinRequest";
+//    }
 
     @Getter
     @Setter

--- a/src/main/java/com/ac/su/joinrequest/JoinRequestRestController.java
+++ b/src/main/java/com/ac/su/joinrequest/JoinRequestRestController.java
@@ -1,6 +1,7 @@
 package com.ac.su.joinrequest;
 
 import com.ac.su.ResponseMessage;
+import com.ac.su.clubmember.ClubMemberId;
 import com.ac.su.clubmember.ClubMemberService;
 import com.ac.su.clubmember.MemberStatus;
 import com.ac.su.member.CustonUser;
@@ -28,18 +29,14 @@ public class JoinRequestRestController {
     @GetMapping("/{clubId}/joinRequest")
     public ResponseEntity<?>  joinRequestList(
             @PathVariable("clubId") Long clubId,
-            @RequestParam("status") MemberStatus status,
             Authentication auth) {
+        // 회원 상태 가져오기
         CustonUser user = (CustonUser) auth.getPrincipal();
-        // 동아리 회장이 아닐 때
+        MemberStatus status = clubMemberService.getMemberStatus(new ClubMemberId(user.getId(), clubId));
+
+        // 동아리 회장이 아닌 경우 접근 금지
         if (status != MemberStatus.CLUB_PRESIDENT) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
-        }
-        // 동아리 회장일 때
-        // PathVariable로 받은 동아리의 회장인지 검사
-        else {
-            if (!clubMemberService.existsById(user.getId(), clubId))
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 
         // 동아리 지원서 리스트 출력
@@ -53,18 +50,14 @@ public class JoinRequestRestController {
     public ResponseEntity<?> requestDetail(
             @PathVariable("clubId") Long clubId,
             @PathVariable("requestId") Long requestId,
-            @RequestParam("status") MemberStatus status,
             Authentication auth) {
+        // 회원 상태 가져오기
         CustonUser user = (CustonUser) auth.getPrincipal();
-        // 동아리 회장이 아닐 때
+        MemberStatus status = clubMemberService.getMemberStatus(new ClubMemberId(user.getId(), clubId));
+
+        // 동아리 회장이 아닌 경우 접근 금지
         if (status != MemberStatus.CLUB_PRESIDENT) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
-        }
-        // 동아리 회장일 때
-        // PathVariable로 받은 동아리의 회장인지 검사
-        else {
-            if (!clubMemberService.existsById(user.getId(), clubId))
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 
         // 동아리 지원서 상세 정보 출력
@@ -79,18 +72,14 @@ public class JoinRequestRestController {
             @PathVariable("requestId") Long requestId,
             @PathVariable("clubId") Long clubId,
             @RequestParam("memberId") Long memberId,
-            @RequestParam("status") MemberStatus status,
             Authentication auth) {
+        // 회원 상태 가져오기
         CustonUser user = (CustonUser) auth.getPrincipal();
-        // 동아리 회장이 아닐 때
+        MemberStatus status = clubMemberService.getMemberStatus(new ClubMemberId(user.getId(), clubId));
+
+        // 동아리 회장이 아닌 경우 접근 금지
         if (status != MemberStatus.CLUB_PRESIDENT) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
-        }
-        // 동아리 회장일 때
-        // PathVariable로 받은 동아리의 회장인지 검사
-        else {
-            if (!clubMemberService.existsById(user.getId(), clubId))
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 
         // 가입 승인
@@ -104,18 +93,14 @@ public class JoinRequestRestController {
     public ResponseEntity<?> denyRequest(
             @PathVariable("requestId") Long requestId,
             @PathVariable("clubId") Long clubId,
-            @RequestParam("status") MemberStatus status,
             Authentication auth) {
+        // 회원 상태 가져오기
         CustonUser user = (CustonUser) auth.getPrincipal();
-        // 동아리 회장이 아닐 때
+        MemberStatus status = clubMemberService.getMemberStatus(new ClubMemberId(user.getId(), clubId));
+
+        // 동아리 회장이 아닌 경우 접근 금지
         if (status != MemberStatus.CLUB_PRESIDENT) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
-        }
-        // 동아리 회장일 때
-        // PathVariable로 받은 동아리의 회장인지 검사
-        else {
-            if (!clubMemberService.existsById(user.getId(), clubId))
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 
         // 가입 거절

--- a/src/main/java/com/ac/su/joinrequest/JoinRequestRestController.java
+++ b/src/main/java/com/ac/su/joinrequest/JoinRequestRestController.java
@@ -3,6 +3,7 @@ package com.ac.su.joinrequest;
 import com.ac.su.ResponseMessage;
 import com.ac.su.clubmember.ClubMemberService;
 import com.ac.su.clubmember.MemberStatus;
+import com.ac.su.member.CustonUser;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -17,7 +18,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/clubs")
+@RequestMapping("/clubs")
 public class JoinRequestRestController {
     private final JoinRequestService joinRequestService;
     private final ClubMemberService clubMemberService;
@@ -29,6 +30,7 @@ public class JoinRequestRestController {
             @PathVariable("clubId") Long clubId,
             @RequestParam("status") MemberStatus status,
             Authentication auth) {
+        CustonUser user = (CustonUser) auth.getPrincipal();
         // 동아리 회장이 아닐 때
         if (status != MemberStatus.CLUB_PRESIDENT) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
@@ -36,7 +38,7 @@ public class JoinRequestRestController {
         // 동아리 회장일 때
         // PathVariable로 받은 동아리의 회장인지 검사
         else {
-            if (!clubMemberService.existsById(Long.valueOf(auth.getName()), clubId))
+            if (!clubMemberService.existsById(user.getId(), clubId))
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 
@@ -53,6 +55,7 @@ public class JoinRequestRestController {
             @PathVariable("requestId") Long requestId,
             @RequestParam("status") MemberStatus status,
             Authentication auth) {
+        CustonUser user = (CustonUser) auth.getPrincipal();
         // 동아리 회장이 아닐 때
         if (status != MemberStatus.CLUB_PRESIDENT) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
@@ -60,7 +63,7 @@ public class JoinRequestRestController {
         // 동아리 회장일 때
         // PathVariable로 받은 동아리의 회장인지 검사
         else {
-            if (!clubMemberService.existsById(Long.valueOf(auth.getName()), clubId))
+            if (!clubMemberService.existsById(user.getId(), clubId))
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 
@@ -78,6 +81,7 @@ public class JoinRequestRestController {
             @RequestParam("memberId") Long memberId,
             @RequestParam("status") MemberStatus status,
             Authentication auth) {
+        CustonUser user = (CustonUser) auth.getPrincipal();
         // 동아리 회장이 아닐 때
         if (status != MemberStatus.CLUB_PRESIDENT) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
@@ -85,7 +89,7 @@ public class JoinRequestRestController {
         // 동아리 회장일 때
         // PathVariable로 받은 동아리의 회장인지 검사
         else {
-            if (!clubMemberService.existsById(Long.valueOf(auth.getName()), clubId))
+            if (!clubMemberService.existsById(user.getId(), clubId))
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 
@@ -102,6 +106,7 @@ public class JoinRequestRestController {
             @PathVariable("clubId") Long clubId,
             @RequestParam("status") MemberStatus status,
             Authentication auth) {
+        CustonUser user = (CustonUser) auth.getPrincipal();
         // 동아리 회장이 아닐 때
         if (status != MemberStatus.CLUB_PRESIDENT) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
@@ -109,7 +114,7 @@ public class JoinRequestRestController {
         // 동아리 회장일 때
         // PathVariable로 받은 동아리의 회장인지 검사
         else {
-            if (!clubMemberService.existsById(Long.valueOf(auth.getName()), clubId))
+            if (!clubMemberService.existsById(user.getId(), clubId))
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseMessage("동아리 회장만 접근 가능합니다"));
         }
 

--- a/src/main/java/com/ac/su/joinrequest/JoinRequestService.java
+++ b/src/main/java/com/ac/su/joinrequest/JoinRequestService.java
@@ -60,7 +60,8 @@ public class JoinRequestService {
 
     // 동아리 id로 동아리 지원서 전체 검색
     public List<JoinRequestDTO> findRequestByClubId(Long clubId) {
-        List<JoinRequest> joinRequestList = joinRequestRepository.findByClubIdAndStatus(clubId, RequestStatus.WAITING);
+//        List<JoinRequest> joinRequestList = joinRequestRepository.findByClubIdAndStatus(clubId, RequestStatus.WAITING);
+        List<JoinRequest> joinRequestList = joinRequestRepository.findByClubId(clubId);
         // 동아리 지원서가 한 개도 없을 때 빈 리스트 반환
         if(joinRequestList.isEmpty()){
             return new ArrayList<>();
@@ -81,10 +82,12 @@ public class JoinRequestService {
 
     // 가입 승인
     public void approveRequest(Long requestId, Long clubId, Long memberId) {
-        JoinRequest joinRequest = joinRequestRepository.findById(requestId).orElseThrow();
-        // 지원서 상태 WAITING -> APPROVED
-        joinRequest.setStatus(RequestStatus.APPROVED);
-        joinRequestRepository.save(joinRequest);
+//        JoinRequest joinRequest = joinRequestRepository.findById(requestId).orElseThrow();
+//        // 지원서 상태 WAITING -> APPROVED
+//        joinRequest.setStatus(RequestStatus.APPROVED);
+//        joinRequestRepository.save(joinRequest);
+        // 가입 승인 후 DB에서 지원서 제거
+        joinRequestRepository.deleteById(requestId);
 
         Club club = clubRepository.findById(clubId).orElseThrow();
         Member member = memberRepository.findById(memberId).orElseThrow();


### PR DESCRIPTION
- 동아리 관리 기능 구현

- 회원 삭제, 탈퇴 기능 수정
  - 동아리 회장일시 위임 후 탈퇴 가능

- 회원 관리 기능 수정
  - 다른 사람을 회장으로 변경할 때 기존 회장의 등급을 일반회원으로 변경
  - 삭제하려는 회원이 회장일시 삭제 불가능

- 그 외 자잘한 수정
  - 안 쓰는 코드들 주석 처리
  - 회장 검증 알고리즘 찐마지막 수정
  -  /api/clubs/~ -> /clubs/~로 링크 통일
 
main과 병합 후 api 테스트까지 완료했습니다~!
